### PR TITLE
Update Audi SQ2 generations: Split into pre-facelift and facelift entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Audi SQ2
 
+This repository contains signal set configurations for the Audi SQ2, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi SQ2.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,12 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q2"
+
 generations:
   - name: "First Generation (GA)"
     start_year: 2019
+    end_year: 2020
+    description: "The Audi SQ2 is the high-performance variant of Audi's smallest SUV. Based on the Volkswagen Group MQB platform, it features a turbocharged 2.0L four-cylinder engine producing 295 HP and 400 Nm of torque, shared with other compact performance models like the Audi S3 and Volkswagen Golf R. Power is delivered to all four wheels via a seven-speed S tronic dual-clutch transmission and quattro all-wheel drive system. Performance is impressive for a compact SUV, with 0-62 mph (0-100 km/h) acceleration in 4.8 seconds. The exterior features more aggressive styling with S-specific bumpers, larger air intakes, quad exhaust tips, and unique 18 or 19-inch wheels. The suspension is lowered by 20mm compared to the standard Q2, and the interior features sport seats, stainless steel pedals, and S-specific displays."
+  - name: "First Generation (GA Facelift)"
+    start_year: 2021
     end_year: null
-    description: "The Audi SQ2 is the high-performance variant of Audi's smallest SUV. Based on the Volkswagen Group MQB platform, it features a turbocharged 2.0L four-cylinder engine producing 300 HP and 400 Nm of torque, shared with other compact performance models like the Audi S3 and Volkswagen Golf R. Power is delivered to all four wheels via a seven-speed S tronic dual-clutch transmission and quattro all-wheel drive system. Performance is impressive for a compact SUV, with 0-62 mph (0-100 km/h) acceleration in 4.8 seconds. The exterior features more aggressive styling with S-specific bumpers, larger air intakes, quad exhaust tips, and unique 18 or 19-inch wheels. The suspension is lowered by 20mm compared to the standard Q2, and the interior features sport seats, stainless steel pedals, and S-specific displays. A facelift in 2021 updated the styling and technology features. The SQ2 represents Audi's approach to creating performance-oriented variants across all segments of its lineup, offering the practicality of a compact SUV with the performance characteristics of a hot hatchback."
+    description: "The 2021 facelift updated the SQ2's styling and technology features while maintaining the same 2.0 TFSI turbocharged engine producing 295 HP and 400 Nm of torque. The facelift introduced updated exterior styling, refreshed interior design with enhanced technology including the latest Audi MMI system, and refined infotainment features. The SQ2 represents Audi's approach to creating performance-oriented variants across all segments of its lineup, offering the practicality of a compact SUV with the performance characteristics of a hot hatchback."


### PR DESCRIPTION
- Split single generation entry into two separate entries (2019-2020 and 2021-present)
- Added facelift as separate generation entry per ML training requirements
- Corrected horsepower from 300 HP to 295 HP per Wikipedia specification
- Added production end year 2020 for pre-facelift generation
- Added references array with Wikipedia source (Audi Q2 article)
- Updated README.md with standard template

Evidence from Wikipedia: Audi Q2 article (https://en.wikipedia.org/wiki/Audi_Q2) documents SQ2 introduction in 2019 with 2.0 TFSI engine producing 295 HP, and gallery images show both pre-facelift (2019 SQ2) and facelift (2021+) versions.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
